### PR TITLE
Adding regex for Slack Incoming Webhook 

### DIFF
--- a/high_entropy_string/__init__.py
+++ b/high_entropy_string/__init__.py
@@ -17,6 +17,8 @@ ENTROPY_PATTERNS_TO_FLAG = [
     re.compile('^[a-z]+://.*:.*@'),
     # PEM encoded PKCS8 private keys
     re.compile('BEGIN.*PRIVATE KEY')
+    # Slack webhook
+    re.compile('https://hooks.slack.com/services')
 ]
 mimetypes.init()
 EXTS = [re.escape(i) for i in mimetypes.types_map.keys()]

--- a/high_entropy_string/__init__.py
+++ b/high_entropy_string/__init__.py
@@ -18,7 +18,7 @@ ENTROPY_PATTERNS_TO_FLAG = [
     # PEM encoded PKCS8 private keys
     re.compile('BEGIN.*PRIVATE KEY')
     # Slack webhook
-    re.compile('https://hooks.slack.com/services')
+    re.compile('https:\/\/hooks.slack.com\/services\/T\w{8}\/B\w{8}\/\w{24}')
 ]
 mimetypes.init()
 EXTS = [re.escape(i) for i in mimetypes.types_map.keys()]

--- a/high_entropy_string/__init__.py
+++ b/high_entropy_string/__init__.py
@@ -16,7 +16,7 @@ ENTROPY_PATTERNS_TO_FLAG = [
     # URLs with username/password combos
     re.compile('^[a-z]+://.*:.*@'),
     # PEM encoded PKCS8 private keys
-    re.compile('BEGIN.*PRIVATE KEY')
+    re.compile('BEGIN.*PRIVATE KEY'),
     # Slack webhook
     re.compile(r'https://hooks.slack.com/services/T\w{8}/B\w{8}/\w{24}')
 ]

--- a/high_entropy_string/__init__.py
+++ b/high_entropy_string/__init__.py
@@ -18,7 +18,7 @@ ENTROPY_PATTERNS_TO_FLAG = [
     # PEM encoded PKCS8 private keys
     re.compile('BEGIN.*PRIVATE KEY')
     # Slack webhook
-    re.compile('https:\/\/hooks.slack.com\/services\/T\w{8}\/B\w{8}\/\w{24}')
+    re.compile(r'https://hooks.slack.com/services/T\w{8}/B\w{8}/\w{24}')
 ]
 mimetypes.init()
 EXTS = [re.escape(i) for i in mimetypes.types_map.keys()]


### PR DESCRIPTION
These web-hooks can be used to post messages to Slack groups. Used this document to come up with this regex: https://api.slack.com/incoming-webhooks 
Note that the regex doesn't end after 24 characters intentionally. This is because I have found instances of 25 characters as well. 