### PR TITLE
Python 3 support with library update

### DIFF
--- a/high_entropy_string/__init__.py
+++ b/high_entropy_string/__init__.py
@@ -264,7 +264,7 @@ class PythonStringData(object):
         else:
             check_str = self.string
         try:
-            entropy = zxcvbn.password_strength(check_str)['entropy']
+            entropy = zxcvbn.zxcvbn(check_str)['score']
         except UnicodeDecodeError:
             logger.warning(
                 'Failed to get entropy due to unicode decode error.'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # License: MIT
-zxcvbn>=1.0,<=2.0
+zxcvbn==4.4.28
 # The modular source code checker: pep8, pyflakes and co
 # License: MIT
 # Upstream url: http://bitbucket.org/tarek/flake8

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ requirements = [
     # License: MIT
     # Upstream url: https://github.com/dropbox/zxcvbn
     # Use: For entropy checks
-    'zxcvbn>=1.0,<=1.999'
+    'zxcvbn==4.4.28'
 ]
 
 setup(


### PR DESCRIPTION
While trying to use it under python 3, zxcvbn was complaining as some of the functions were not supported under python 3. Hence updated the version of that library to latest since it now supports python 3. 

The function `password_strength` in from `zxcvbn` call was replaced as suggested by the library. 